### PR TITLE
Get UUID workaround

### DIFF
--- a/src/Net-UDAP/lib/Net/UDAP.pm
+++ b/src/Net-UDAP/lib/Net/UDAP.pm
@@ -328,13 +328,13 @@ __PACKAGE__->mk_accessors( keys %field_default );
 
     sub callback_set_ip {
         my ( $self, $msg_ref ) = @_;
-        log( debug => '>>> processing set_ip packet' );
+        log( debug => '>>> received set_ip packet (NOOP)' );
         return;
     }
 
     sub callback_reset {
         my ( $self, $msg_ref ) = @_;
-        log( debug => '>>> processing reset packet' );
+        log( debug => '>>> received reset packet (NOOP)' );
         return;
     }
 
@@ -346,25 +346,25 @@ __PACKAGE__->mk_accessors( keys %field_default );
 
     sub callback_set_data {
         my ( $self, $msg_ref ) = @_;
-        log( debug => '>>> processing set_data packet' );
+        log( debug => '>>> received set_data packet (NOOP)' );
         return;
     }
 
     sub callback_error {
         my ( $self, $msg_ref ) = @_;
-        log( debug => '>>> processing error packet' );
+        log( debug => '>>> received error packet (NOOP)' );
         return;
     }
 
     sub callback_credentials_error {
         my ( $self, $msg_ref ) = @_;
-        log( debug => '>>> processing credentials_error packet' );
+        log( debug => '>>> received credentials_error packet (NOOP)' );
         return;
     }
 
     sub callback_get_uuid {
         my ( $self, $msg_ref ) = @_;
-        log( debug => '>>> processing get_uuid packet' );
+        log( debug => '>>> received get_uuid packet (NOOP)' );
         return;
     }
 

--- a/src/Net-UDAP/lib/Net/UDAP.pm
+++ b/src/Net-UDAP/lib/Net/UDAP.pm
@@ -282,6 +282,8 @@ __PACKAGE__->mk_accessors( keys %field_default );
         UCP_METHOD_ADV_DISCOVER(),      \&callback_discover,
 
         # UCP_METHOD_TEN,               undef,
+
+        UCP_METHOD_GET_UUID(),          \&callback_get_uuid,
     );
 
     sub process_msg {
@@ -360,6 +362,12 @@ __PACKAGE__->mk_accessors( keys %field_default );
         return;
     }
 
+    sub callback_get_uuid {
+        my ( $self, $msg_ref ) = @_;
+        log( debug => '>>> processing get_uuid packet' );
+        return;
+    }
+
     sub add_client {
         my ( $self, $msg_ref ) = @_;
         croak '$msg_ref not a Net::UDAP::MessageIn object'
@@ -416,8 +424,8 @@ This document describes Net::UDAP version 0.1
     Brief code example(s) here showing commonest usage(s).
     This section will be as far as many users bother reading
     so make it as educational and exeplary as possible.
-  
-  
+
+
 =head1 DESCRIPTION
 
 =for author to fill in:
@@ -425,7 +433,7 @@ This document describes Net::UDAP version 0.1
     Use subsections (=head2, =head3) as appropriate.
 
 
-=head1 INTERFACE 
+=head1 INTERFACE
 
 =for author to fill in:
     Write a separate section listing the public components of the modules
@@ -465,7 +473,7 @@ This document describes Net::UDAP version 0.1
     files, and the meaning of any environment variables or properties
     that can be set. These descriptions must also include details of any
     configuration language used.
-  
+
 Net::UDAP requires no configuration files or environment variables.
 
 

--- a/src/Net-UDAP/lib/Net/UDAP/Constant.pm
+++ b/src/Net-UDAP/lib/Net/UDAP/Constant.pm
@@ -45,7 +45,7 @@ use Exporter qw(import);
         qw( UCP_CODE_ZERO UCP_CODE_ONE UCP_CODE_DEVICE_NAME UCP_CODE_DEVICE_TYPE UCP_CODE_USE_DHCP UCP_CODE_IP_ADDR UCP_CODE_SUBNET_MASK UCP_CODE_GATEWAY_ADDR UCP_CODE_EIGHT UCP_CODE_FIRMWARE_REV UCP_CODE_HARDWARE_REV UCP_CODE_DEVICE_ID UCP_CODE_DEVICE_STATUS UCP_CODE_UUID )
     ],
     UCP_METHODS => [
-        qw( UCP_METHOD_ZERO UCP_METHOD_DISCOVER UCP_METHOD_GET_IP UCP_METHOD_SET_IP UCP_METHOD_RESET UCP_METHOD_GET_DATA UCP_METHOD_SET_DATA UCP_METHOD_ERROR UCP_METHOD_CREDENTIALS_ERROR UCP_METHOD_ADV_DISCOVER UCP_METHOD_TEN )
+        qw( UCP_METHOD_ZERO UCP_METHOD_DISCOVER UCP_METHOD_GET_IP UCP_METHOD_SET_IP UCP_METHOD_RESET UCP_METHOD_GET_DATA UCP_METHOD_SET_DATA UCP_METHOD_ERROR UCP_METHOD_CREDENTIALS_ERROR UCP_METHOD_ADV_DISCOVER UCP_METHOD_TEN UCP_METHOD_GET_UUID)
     ],
     WLAN_MODES       => [qw( WLAN_MODE_INFRASTRUCTURE WLAN_MODE_ADHOC )],
     WLAN_REGIONS_ATH => [
@@ -444,8 +444,8 @@ This document describes Net::UDAP::Constant version 0.0.1
     Brief code example(s) here showing commonest usage(s).
     This section will be as far as many users bother reading
     so make it as educational and exeplary as possible.
-  
-  
+
+
 =head1 DESCRIPTION
 
 =for author to fill in:
@@ -453,7 +453,7 @@ This document describes Net::UDAP::Constant version 0.0.1
     Use subsections (=head2, =head3) as appropriate.
 
 
-=head1 INTERFACE 
+=head1 INTERFACE
 
 =for author to fill in:
     Write a separate section listing the public components of the modules
@@ -493,7 +493,7 @@ This document describes Net::UDAP::Constant version 0.0.1
     files, and the meaning of any environment variables or properties
     that can be set. These descriptions must also include details of any
     configuration language used.
-  
+
 Net::UDAP::Constant requires no configuration files or environment variables.
 
 


### PR DESCRIPTION
As per #7, Squeezebox Radio devices return a ucp method that is not handled in the code ( 0x000B - get_uuid ).

This change handles that method code, and also clarifies some of the debug logging messages written from the message handler.

FIxes #7.